### PR TITLE
Add download incidents route

### DIFF
--- a/incident_reporting/main.py
+++ b/incident_reporting/main.py
@@ -6,7 +6,12 @@ from pathlib import Path
 import polars as pl
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse, JSONResponse, Response
+from fastapi.responses import (
+    HTMLResponse,
+    JSONResponse,
+    Response,
+    StreamingResponse,
+)
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -222,4 +227,22 @@ def get_yearly_incident_counts() -> JSONResponse:
             "counts": [tc[1] for tc in type_counts_list],
             "types": [tc[0] for tc in type_counts_list],
         }
+    )
+
+
+@app.get(
+    "/incidents/all",
+    response_class=StreamingResponse,
+    status_code=HTTPStatus.OK,
+)
+def get_all_incidents_as_file() -> StreamingResponse:
+    df, _ = client.get_last_year_of_incidents()
+    df_pandas = df.to_pandas()
+
+    return StreamingResponse(
+        iter([df_pandas.to_csv(index=False)]),
+        media_type="text/csv",
+        headers={
+            "Content-Disposition": "attachment; filename=all_incident_data.csv"
+        },
     )

--- a/incident_reporting/main.py
+++ b/incident_reporting/main.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import date
 from http import HTTPMethod, HTTPStatus
 from pathlib import Path
 
@@ -238,11 +239,13 @@ def get_yearly_incident_counts() -> JSONResponse:
 def get_all_incidents_as_file() -> StreamingResponse:
     df, _ = client.get_last_year_of_incidents()
     df_pandas = df.to_pandas()
+    today = date.today().strftime("%m-%d-%Y")
+    headers = {
+        "Content-Disposition": f"attachment; filename=ucpd-incident-data.{today}.csv"
+    }
 
     return StreamingResponse(
         iter([df_pandas.to_csv(index=False)]),
         media_type="text/csv",
-        headers={
-            "Content-Disposition": "attachment; filename=all_incident_data.csv"
-        },
+        headers=headers,
     )

--- a/incident_reporting/templates/home.html
+++ b/incident_reporting/templates/home.html
@@ -9,6 +9,9 @@
       This project was undertaken with the goal of showing a more granular picture of incidents posted on
       the <a href="https://incidentreports.uchicago.edu/" target="_blank">UCPD Incident Report</a> page.
     </p>
+    <p>
+      If you would like to download all of the scraped UCPD Data, click here: <a href='{{ url_for("get_all_incidents_as_file") }}'>Link</a>
+    </p>
     <h3>The current analysis of the incident data is listed below:</h3>
     <ul>
       <li>


### PR DESCRIPTION
## Describe your changes
Add route that allows you to download all incidents.

## Checklist before requesting a review
- [x] The code runs successfully.

```commandline
(ucpd-incident-reporting-py3.11) michaelp@MacBook-Air-18 ucpd-incident-reporting % make run
uvicorn incident_reporting.main:app --reload --host 0.0.0.0 --port 8000
INFO:     Will watch for changes in these directories: ['/Users/michaelp/Documents/GitHub/ucpd-incident-reporting']
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:     Started reloader process [87829] using StatReload
INFO:     Started server process [87832]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     127.0.0.1:63467 - "GET / HTTP/1.1" 200 OK
INFO:     127.0.0.1:63467 - "GET /incidents/all HTTP/1.1" 200 OK
```
