### PR TITLE
Update ID address for page visits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lint:
 
 .PHONY: run
 run:
-	gunicorn incident_reporting.main:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --reload
+	gunicorn incident_reporting.main:app --worker-class uvicorn.workers.UvicornWorker --reload
 
 .PHONY: deploy
 deploy:

--- a/incident_reporting/main.py
+++ b/incident_reporting/main.py
@@ -54,7 +54,7 @@ app.add_middleware(
         "http://0.0.0.0:8000",
         "https://0.0.0.0:8000",
         "https://total-thinker-381819.uc.r.appspot.com/",
-        "https://ucpd-incident-reporter.michplunkett.com/"
+        "https://ucpd-incident-reporter.michplunkett.com/",
     ],
     allow_credentials=True,
     allow_methods=[HTTPMethod.GET],

--- a/incident_reporting/main.py
+++ b/incident_reporting/main.py
@@ -72,7 +72,7 @@ def log_page_visit(page: str, request: Request) -> None:
         # If the X-Forwarded-For header is not available, fall back to request.client
         client_ip = request.client.host
 
-    logging.info(f"{page} from this IP address: {client_ip}")
+    logging.info(f"{page} requested from this IP address: {client_ip}")
 
 
 @app.get("/", response_class=HTMLResponse, status_code=HTTPStatus.OK)

--- a/incident_reporting/main.py
+++ b/incident_reporting/main.py
@@ -54,6 +54,7 @@ app.add_middleware(
         "http://0.0.0.0:8000",
         "https://0.0.0.0:8000",
         "https://total-thinker-381819.uc.r.appspot.com/",
+        "https://ucpd-incident-reporter.michplunkett.com/"
     ],
     allow_credentials=True,
     allow_methods=[HTTPMethod.GET],


### PR DESCRIPTION
## Describe your changes
Address issue where the application was not recording the actual IP address that the requests were coming form due to GCP proxies.

## Checklist before requesting a review
- [x] The code runs successfully.

```commandline
(ucpd-incident-reporting-py3.11) michaelp@MacBook-Air-18 ucpd-incident-reporting % make run
gunicorn incident_reporting.main:app --worker-class uvicorn.workers.UvicornWorker --reload
[2024-09-04 22:48:39 -0700] [13885] [INFO] Starting gunicorn 22.0.0
[2024-09-04 22:48:39 -0700] [13885] [INFO] Listening at: http://127.0.0.1:8000 (13885)
[2024-09-04 22:48:39 -0700] [13885] [INFO] Using worker: uvicorn.workers.UvicornWorker
[2024-09-04 22:48:39 -0700] [13886] [INFO] Booting worker with pid: 13886
[2024-09-04 22:48:40 -0700] [13886] [INFO] Started server process [13886]
[2024-09-04 22:48:40 -0700] [13886] [INFO] Waiting for application startup.
[2024-09-04 22:48:40 -0700] [13886] [INFO] Application startup complete.
Home page from this IP address: 127.0.0.1
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1725515325.120841   93936 check_gcp_environment_no_op.cc:29] ALTS: Platforms other than Linux and Windows are not supported
Incident map from this IP address: 127.0.0.1
```